### PR TITLE
Do not assign delete! return value to original

### DIFF
--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -32,7 +32,7 @@ module OneLogin
       #
       def self.format_private_key(key, heads=true)
         if key && !key.empty?
-          key = key.delete!("\n\r\x0D")
+          key.delete!("\n\r\x0D")
           if key.index('-----BEGIN PRIVATE KEY-----') != nil
             key = key.gsub('-----BEGIN PRIVATE KEY-----', '')
             key = key.gsub('-----END PRIVATE KEY-----', '')

--- a/lib/onelogin/ruby-saml/utils.rb
+++ b/lib/onelogin/ruby-saml/utils.rb
@@ -2,11 +2,11 @@ module OneLogin
   module RubySaml
 
     # SAML2 Auxiliary class
-    #    
+    #
     class Utils
 
       # Return the x509 certificate string formatted
-      # @param cert [String] The original certificate 
+      # @param cert [String] The original certificate
       # @param heads [Boolean] If true, the formatted certificate will include the
       #                        "BEGIN CERTIFICATE" header and the footer.
       # @return [String] The formatted certificate
@@ -25,14 +25,14 @@ module OneLogin
       end
 
       # Return the private key string formatted
-      # @param key [String] The original private key 
+      # @param key [String] The original private key
       # @param heads [Boolean] If true, the formatted private key will include the
       #                  "BEGIN PRIVATE KEY" or the "BEGIN RSA PRIVATE KEY" header and the footer.
       # @return [String] The formatted certificate
       #
       def self.format_private_key(key, heads=true)
         if key && !key.empty?
-          key.delete!("\n\r\x0D")
+          key = key.delete("\n\r\x0D")
           if key.index('-----BEGIN PRIVATE KEY-----') != nil
             key = key.gsub('-----BEGIN PRIVATE KEY-----', '')
             key = key.gsub('-----END PRIVATE KEY-----', '')

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,0 +1,44 @@
+require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
+
+require 'onelogin/ruby-saml/utils'
+
+class UtilsTest < Minitest::Test
+
+  describe "Utils" do
+
+    describe "format_private_key" do
+      let(:private_key) { File.read(File.expand_path('../certificates/ruby-saml.key', __FILE__)) }
+      let(:unformatted_private_key) { private_key.gsub(/[\n\r\x0D]/, "") }
+      let(:ugly_private_key) do
+        unformatted_private_key.insert(61, "\n").insert(104, "\n") \
+          .insert(120, "\n").insert(203, "\n").insert(341, "\n") \
+          .insert(410, "\n").insert(464, "\n").insert(715, "\n")
+      end
+
+      it "doesn't change a well-formatted key" do
+        assert_equal private_key, OneLogin::RubySaml::Utils.format_private_key(private_key)
+      end
+
+      it "formats a key with no newlines" do
+        assert_equal private_key, OneLogin::RubySaml::Utils.format_private_key(unformatted_private_key)
+      end
+
+      it "formats an ugly key with random newlines" do
+        assert_equal private_key, OneLogin::RubySaml::Utils.format_private_key(ugly_private_key)
+      end
+
+      it "returns only the material if 'heads' parameter is false" do
+        formatted_key = OneLogin::RubySaml::Utils.format_private_key(private_key, false)
+        refute_match /-----BEGIN RSA PRIVATE KEY-----/, formatted_key
+        refute_match /-----END RSA PRIVATE KEY-----/, formatted_key
+      end
+
+      it "returns headers if 'heads' parameter is true" do
+        formatted_key = OneLogin::RubySaml::Utils.format_private_key(private_key, true)
+        assert_match /-----BEGIN RSA PRIVATE KEY-----/, formatted_key
+        assert_match /-----END RSA PRIVATE KEY-----/, formatted_key
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
When delete! is called and nothing can be deleted (for example, when format_private_key is called a second time), a nil is returned. This results in "undefined method `index' for nil:NilClass"

Signed-off-by: Justin Gaylor justin@rightscale.com
